### PR TITLE
feat: add reorganize skill + integrate into code-quality-loop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "AI-driven code review with independent adversarial review, automated quality polish, and multi-language static analysis",
-    "version": "2.0.0"
+    "version": "2.1.0"
   },
   "plugins": [
     {
       "name": "review-loop",
       "source": "./",
       "description": "AI-driven code review with independent adversarial review, automated quality polish, and multi-language static analysis. 12 agents, 5 skills, full Plan-Execute-Review-Polish pipeline.",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "author": {
         "name": "NYTC69"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "review-loop",
       "source": "./",
-      "description": "AI-driven code review with independent adversarial review, automated quality polish, and multi-language static analysis. 12 agents, 4 skills, full Plan-Execute-Review-Polish pipeline.",
+      "description": "AI-driven code review with independent adversarial review, automated quality polish, and multi-language static analysis. 12 agents, 5 skills, full Plan-Execute-Review-Polish pipeline.",
       "version": "2.0.0",
       "author": {
         "name": "NYTC69"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "review-loop",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "AI-driven code review with independent adversarial review, automated quality polish, and multi-language static analysis. 12 agents, 5 skills, full Plan-Execute-Review-Polish pipeline.",
   "author": {
     "name": "NYTC69",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "review-loop",
   "version": "2.0.0",
-  "description": "AI-driven code review with independent adversarial review, automated quality polish, and multi-language static analysis. 12 agents, 4 skills, full Plan-Execute-Review-Polish pipeline.",
+  "description": "AI-driven code review with independent adversarial review, automated quality polish, and multi-language static analysis. 12 agents, 5 skills, full Plan-Execute-Review-Polish pipeline.",
   "author": {
     "name": "NYTC69",
     "url": "https://github.com/NYTC69"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cp ~/.claude/plugins/cache/review-loop/review-loop-config.example.md .claude/rev
 │
 ├── 3. Quality Polish (automatic)
 │   Language-specific static analysis → code quality review →
-│   code simplification → test coverage check
+│   reorganize → code simplification → test coverage check
 │
 └── 4. Delivery
     Findings table + quality summary + time breakdown
@@ -59,9 +59,10 @@ The Executor revises. The Reviewer approves on round 2.
 `RateLimitLayer` was applied globally instead of per-route and flags plan
 conformance violation. Fixed and approved on round 2.
 
-**Quality Polish** — `rust-reviewer` runs `cargo clippy`, `code-simplifier`
-removes a redundant `.clone()`, `pr-test-analyzer` notes missing test for
-the 429 response path.
+**Quality Polish** — `rust-reviewer` runs `cargo clippy`, `reorganize`
+restructures the handler into focused modules, `code-simplifier` removes a
+redundant `.clone()`, `pr-test-analyzer` notes missing test for the 429
+response path.
 
 **Delivery** — Full findings table, quality summary, and time breakdown are
 shown. Optionally auto-commits the result.
@@ -73,6 +74,18 @@ shown. Optionally auto-commits the result.
 Run quality polish independently on existing code. Same agents as Step 3.5
 but triggered on demand — useful for cleaning up code that was written
 outside the review-loop workflow.
+
+### `/review-loop:reorganize <file/dir or 'diff'>`
+
+Restructure code files: rearrange module layout, extract shared logic, remove
+redundancy, add section comments. Splits coupled files into focused modules.
+Preserves all functionality — this is restructuring, not rewriting.
+
+```
+/review-loop:reorganize src/engine.go    # single file
+/review-loop:reorganize src/core/        # directory
+/review-loop:reorganize diff             # all uncommitted changes
+```
 
 ### `/review-loop:review-pr [aspects]`
 
@@ -176,9 +189,9 @@ Stuck detection stops the loop if the same issue recurs 3 rounds without
 progress.
 
 **Quality Polish** — After the adversarial review loop approves, a suite of
-specialized agents automatically runs static analysis, simplification, test
-coverage, and comment checks. Configurable via `quality_focus` and
-`skip_quality_polish`.
+specialized agents automatically runs static analysis, reorganization,
+simplification, test coverage, and comment checks. Configurable via
+`quality_focus` and `skip_quality_polish`.
 
 ## File Structure
 
@@ -189,6 +202,8 @@ review-loop/
 │   │   └── SKILL.md              ← Orchestrator instructions
 │   ├── code-quality-loop/
 │   │   └── SKILL.md              ← Standalone quality polish
+│   ├── reorganize/
+│   │   └── SKILL.md              ← Code file restructuring
 │   ├── review-pr/
 │   │   └── SKILL.md              ← Spot-check specific aspects
 │   └── guide/

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cp ~/.claude/plugins/cache/review-loop/review-loop-config.example.md .claude/rev
 │
 ├── 3. Quality Polish (automatic)
 │   Language-specific static analysis → code quality review →
-│   reorganize → code simplification → test coverage check
+│   code simplification → test coverage check
 │
 └── 4. Delivery
     Findings table + quality summary + time breakdown
@@ -59,10 +59,9 @@ The Executor revises. The Reviewer approves on round 2.
 `RateLimitLayer` was applied globally instead of per-route and flags plan
 conformance violation. Fixed and approved on round 2.
 
-**Quality Polish** — `rust-reviewer` runs `cargo clippy`, `reorganize`
-restructures the handler into focused modules, `code-simplifier` removes a
-redundant `.clone()`, `pr-test-analyzer` notes missing test for the 429
-response path.
+**Quality Polish** — `rust-reviewer` runs `cargo clippy`, `code-simplifier`
+removes a redundant `.clone()`, `pr-test-analyzer` notes missing test for
+the 429 response path.
 
 **Delivery** — Full findings table, quality summary, and time breakdown are
 shown. Optionally auto-commits the result.
@@ -189,9 +188,9 @@ Stuck detection stops the loop if the same issue recurs 3 rounds without
 progress.
 
 **Quality Polish** — After the adversarial review loop approves, a suite of
-specialized agents automatically runs static analysis, reorganization,
-simplification, test coverage, and comment checks. Configurable via
-`quality_focus` and `skip_quality_polish`.
+specialized agents automatically runs static analysis, simplification, test
+coverage, and comment checks. Configurable via `quality_focus` and
+`skip_quality_polish`.
 
 ## File Structure
 

--- a/skills/code-quality-loop/SKILL.md
+++ b/skills/code-quality-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-quality-loop
-description: "Iterative review-fix loop: reviews code, auto-fixes issues, repeats until clean or stuck. Finishes with simplify + test consolidation."
+description: "Iterative review-fix loop: reviews code, auto-fixes issues, repeats until clean or stuck. Finishes with reorganize, simplify + test consolidation."
 argument-hint: "[max-rounds]"
 ---
 
@@ -14,7 +14,7 @@ Automated code review cycle: review -> fix -> re-review until clean. Focuses on 
 Pre-loop:  language-specific agents -> fix (once per detected language)
 Loop R1:   code-reviewer + silent-failure-hunter + comment-analyzer + type-design-analyzer -> triage -> fix
 Loop R2+:  code-reviewer + silent-failure-hunter -> triage -> fix -> repeat
-Finalize:  code-simplifier agent -> build -> test consolidation -> pr-test-analyzer
+Finalize:  /review-loop:reorganize diff -> code-simplifier agent -> build -> test consolidation -> pr-test-analyzer
 ```
 
 ## Arguments
@@ -313,7 +313,11 @@ Do NOT run tests after each fix. Testing happens once in the Finalize phase.
 
 Execute the following steps regardless of how the loop ended (CLEAN, STUCK, or MAX_ROUNDS). Code has been partially modified and must be left in a buildable, testable state.
 
-### Step 1: Simplify + Build
+### Step 1: Reorganize
+
+Run `/review-loop:reorganize diff` to restructure changed files — rearrange module layout, extract shared logic, remove redundancy, add section separators and comments. The reorganize skill includes its own build verification.
+
+### Step 2: Simplify + Build
 
 Launch the `code-simplifier` agent for final code polish (auto-fix). Due to the known plugin agent type sandbox bug, invoke code-simplifier via `subagent_type: general-purpose` with the agent's full body inlined in the prompt:
 
@@ -349,9 +353,9 @@ Then verify compilation. Detect build command from the languages found during in
 - Multiple languages: run all applicable build checks
 - No specific build tool: skip build check
 
-If build fails -> fix the compilation error and rebuild. Max 3 attempts. If still failing after 3 attempts, report to user and continue to Step 2.
+If build fails -> fix the compilation error and rebuild. Max 3 attempts. If still failing after 3 attempts, report to user and continue to Step 3.
 
-### Step 2: Test consolidation
+### Step 3: Test consolidation
 
 Consolidate tests for the changed code:
 - Keep only tests for critical logic paths
@@ -371,7 +375,7 @@ Detect test command from project languages:
 
 Max 3 fix cycles. If still failing after 3 attempts, report remaining failures to user and continue.
 
-### Step 3: Test quality gate
+### Step 4: Test quality gate
 
 Launch the `pr-test-analyzer` agent to verify test quality (coverage gaps, missing edge cases):
 
@@ -406,10 +410,11 @@ If issues found -> fix and re-run tests.
 
 Max 2 fix cycles. If still failing, report to user and continue.
 
-**Finalize output (all 3 steps):**
+**Finalize output (all 4 steps):**
 
 ```
 -- FINALIZE ------------------------------------------
+[REORGANIZE]   {/review-loop:reorganize output (see reorganize skill)}
 [SIMPLIFY]     {X improvements applied / 0 (already clean)}
 [BUILD]        {PASS / FAIL -> fixed (attempt {n}/3) / FAIL (unresolved)}
 [TESTS]

--- a/skills/code-quality-loop/SKILL.md
+++ b/skills/code-quality-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-quality-loop
-description: "Iterative review-fix loop: reviews code, auto-fixes issues, repeats until clean or stuck. Finishes with reorganize, simplify + test consolidation."
+description: "Iterative review-fix loop: reviews code, auto-fixes issues, repeats until clean or stuck. Finishes with simplify + test consolidation."
 argument-hint: "[max-rounds]"
 ---
 
@@ -14,7 +14,7 @@ Automated code review cycle: review -> fix -> re-review until clean. Focuses on 
 Pre-loop:  language-specific agents -> fix (once per detected language)
 Loop R1:   code-reviewer + silent-failure-hunter + comment-analyzer + type-design-analyzer -> triage -> fix
 Loop R2+:  code-reviewer + silent-failure-hunter -> triage -> fix -> repeat
-Finalize:  /review-loop:reorganize diff -> code-simplifier agent -> build -> test consolidation -> pr-test-analyzer
+Finalize:  code-simplifier agent -> build -> test consolidation -> pr-test-analyzer
 ```
 
 ## Arguments
@@ -313,11 +313,7 @@ Do NOT run tests after each fix. Testing happens once in the Finalize phase.
 
 Execute the following steps regardless of how the loop ended (CLEAN, STUCK, or MAX_ROUNDS). Code has been partially modified and must be left in a buildable, testable state.
 
-### Step 1: Reorganize
-
-Run `/review-loop:reorganize diff` to restructure changed files — rearrange module layout, extract shared logic, remove redundancy, add section separators and comments. The reorganize skill includes its own build verification.
-
-### Step 2: Simplify + Build
+### Step 1: Simplify + Build
 
 Launch the `code-simplifier` agent for final code polish (auto-fix). Due to the known plugin agent type sandbox bug, invoke code-simplifier via `subagent_type: general-purpose` with the agent's full body inlined in the prompt:
 
@@ -353,9 +349,9 @@ Then verify compilation. Detect build command from the languages found during in
 - Multiple languages: run all applicable build checks
 - No specific build tool: skip build check
 
-If build fails -> fix the compilation error and rebuild. Max 3 attempts. If still failing after 3 attempts, report to user and continue to Step 3.
+If build fails -> fix the compilation error and rebuild. Max 3 attempts. If still failing after 3 attempts, report to user and continue to Step 2.
 
-### Step 3: Test consolidation
+### Step 2: Test consolidation
 
 Consolidate tests for the changed code:
 - Keep only tests for critical logic paths
@@ -375,7 +371,7 @@ Detect test command from project languages:
 
 Max 3 fix cycles. If still failing after 3 attempts, report remaining failures to user and continue.
 
-### Step 4: Test quality gate
+### Step 3: Test quality gate
 
 Launch the `pr-test-analyzer` agent to verify test quality (coverage gaps, missing edge cases):
 
@@ -410,11 +406,10 @@ If issues found -> fix and re-run tests.
 
 Max 2 fix cycles. If still failing, report to user and continue.
 
-**Finalize output (all 4 steps):**
+**Finalize output (all 3 steps):**
 
 ```
 -- FINALIZE ------------------------------------------
-[REORGANIZE]   {/review-loop:reorganize output (see reorganize skill)}
 [SIMPLIFY]     {X improvements applied / 0 (already clean)}
 [BUILD]        {PASS / FAIL -> fixed (attempt {n}/3) / FAIL (unresolved)}
 [TESTS]

--- a/skills/code-quality-loop/SKILL.md
+++ b/skills/code-quality-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-quality-loop
-description: "Iterative review-fix loop: reviews code, auto-fixes issues, repeats until clean or stuck. Finishes with simplify + test consolidation."
+description: "Iterative review-fix loop: reviews code, auto-fixes issues, repeats until clean or stuck. Finishes with reorganize (for large changes), simplify + test consolidation."
 argument-hint: "[max-rounds]"
 ---
 
@@ -14,12 +14,19 @@ Automated code review cycle: review -> fix -> re-review until clean. Focuses on 
 Pre-loop:  language-specific agents -> fix (once per detected language)
 Loop R1:   code-reviewer + silent-failure-hunter + comment-analyzer + type-design-analyzer -> triage -> fix
 Loop R2+:  code-reviewer + silent-failure-hunter -> triage -> fix -> repeat
-Finalize:  code-simplifier agent -> build -> test consolidation -> pr-test-analyzer
+Finalize:  reorganize (if applicable) -> code-simplifier agent -> build -> test consolidation -> pr-test-analyzer
 ```
 
 ## Arguments
 
-`$ARGUMENTS`: Optional max round count. Example: `/code-quality-loop 3`. Default: 5.
+`$ARGUMENTS`: Optional flags and max round count.
+
+- **Max rounds**: `/code-quality-loop 3` — limit to 3 rounds (default: 5)
+- **Skip reorganize**: `/code-quality-loop --skip-reorganize` — skip the Reorganize step in Finalize
+- **Force reorganize**: `/code-quality-loop --reorganize` — always run Reorganize regardless of change size
+- **Combined**: `/code-quality-loop 3 --skip-reorganize`
+
+If neither `--skip-reorganize` nor `--reorganize` is specified, the Orchestrator decides automatically based on change scope (see Finalize Step 1).
 
 ## Initialization
 
@@ -313,7 +320,23 @@ Do NOT run tests after each fix. Testing happens once in the Finalize phase.
 
 Execute the following steps regardless of how the loop ended (CLEAN, STUCK, or MAX_ROUNDS). Code has been partially modified and must be left in a buildable, testable state.
 
-### Step 1: Simplify + Build
+### Step 1: Reorganize (conditional)
+
+**Skip if** `--skip-reorganize` was passed. **Always run if** `--reorganize` was passed.
+
+**If neither flag was passed**, decide automatically: examine the scope of changes from Initialization (file count, total lines changed via `git diff --stat`). Apply this heuristic:
+- **Skip**: <= 3 files changed AND <= 100 lines changed — likely a bug fix or small patch
+- **Run**: > 3 files changed OR > 100 lines changed — likely a feature or significant refactor
+
+Run `/review-loop:reorganize diff` to restructure changed files. The reorganize skill includes its own build verification.
+
+**Output:**
+
+```
+[REORGANIZE]   {skipped (small change) / skipped (--skip-reorganize) / ran (see reorganize output)}
+```
+
+### Step 2: Simplify + Build
 
 Launch the `code-simplifier` agent for final code polish (auto-fix). Due to the known plugin agent type sandbox bug, invoke code-simplifier via `subagent_type: general-purpose` with the agent's full body inlined in the prompt:
 
@@ -349,9 +372,9 @@ Then verify compilation. Detect build command from the languages found during in
 - Multiple languages: run all applicable build checks
 - No specific build tool: skip build check
 
-If build fails -> fix the compilation error and rebuild. Max 3 attempts. If still failing after 3 attempts, report to user and continue to Step 2.
+If build fails -> fix the compilation error and rebuild. Max 3 attempts. If still failing after 3 attempts, report to user and continue to Step 3.
 
-### Step 2: Test consolidation
+### Step 3: Test consolidation
 
 Consolidate tests for the changed code:
 - Keep only tests for critical logic paths
@@ -371,7 +394,7 @@ Detect test command from project languages:
 
 Max 3 fix cycles. If still failing after 3 attempts, report remaining failures to user and continue.
 
-### Step 3: Test quality gate
+### Step 4: Test quality gate
 
 Launch the `pr-test-analyzer` agent to verify test quality (coverage gaps, missing edge cases):
 
@@ -406,10 +429,11 @@ If issues found -> fix and re-run tests.
 
 Max 2 fix cycles. If still failing, report to user and continue.
 
-**Finalize output (all 3 steps):**
+**Finalize output (all 4 steps):**
 
 ```
 -- FINALIZE ------------------------------------------
+[REORGANIZE]   {skipped (small change) / skipped (--skip-reorganize) / ran (see output above)}
 [SIMPLIFY]     {X improvements applied / 0 (already clean)}
 [BUILD]        {PASS / FAIL -> fixed (attempt {n}/3) / FAIL (unresolved)}
 [TESTS]

--- a/skills/reorganize/SKILL.md
+++ b/skills/reorganize/SKILL.md
@@ -59,6 +59,8 @@ If the file is already focused and coherent, do not split.
 
 After splitting, apply steps 2.3-2.7 to each resulting file.
 
+**Import fixing**: After splitting, scan the project for files that import or reference the original file. If the split moved symbols to new files, update the affected imports. This may require modifying files outside the original target scope — this is the only case where that is allowed.
+
 #### 2.3 Restructure File Layout
 
 Organize code blocks in a logical order based on the file's actual content. Common reference (adapt as needed):
@@ -74,13 +76,7 @@ Organize code blocks in a logical order based on the file's actual content. Comm
 
 Core principle: **a reader scanning top-to-bottom should naturally understand the file's structure and business flow**. Keep related code together; high-level logic before implementation details.
 
-Separate functional sections with divider comments:
-
-```
-// ============================================================
-// Order Management
-// ============================================================
-```
+Separate functional sections with divider comments. First check if the project already uses a divider style (scan existing files for patterns like `// ---`, `// ===`, `#region`, etc.) and adopt that style. If no existing convention is found, use a simple comment divider appropriate for the language.
 
 #### 2.4 Extract Reusable Logic
 

--- a/skills/reorganize/SKILL.md
+++ b/skills/reorganize/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: reorganize
+description: "Reorganize code file structure: rearrange modules, extract reuse, remove redundancy, add section comments. Preserves all functionality and logic."
+argument-hint: "<file/dir or 'diff'>"
+---
+
+# Code File Reorganization
+
+Restructure the specified code files: rearrange module layout, reorder logically, extract shared logic, remove redundancy, add section separators and comments. **Must not change any functionality or logic.**
+
+## Target Scope
+
+`$ARGUMENTS` specifies the target:
+- **File path**: `/reorganize src/engine.go` — reorganize a single file
+- **Directory path**: `/reorganize src/core/` — reorganize all code files in the directory
+- **`diff`**: `/reorganize diff` — reorganize all uncommitted files (via `git diff --name-only --diff-filter=d HEAD`)
+
+If no argument is provided, prompt the user to specify a target.
+
+## Execution Flow
+
+### Step 1: Determine File List
+
+Resolve the file list from `$ARGUMENTS`. For directories, recursively collect all code files (excluding vendor, node_modules, generated files, etc.). For `diff`, collect all uncommitted modified files (staged + unstaged).
+
+Output:
+
+```
+REORGANIZE
+  Target:    {file/dir/diff}
+  Files:     {N} files
+  {file list}
+```
+
+### Step 2: Analyze and Reorganize Each File
+
+Process files one at a time. Complete each file before moving to the next.
+
+#### 2.1 Read and Analyze Current Structure
+
+Read the entire file and analyze:
+- All type definitions, constants, variables, functions/methods present
+- Dependencies and relationships between sections
+- Duplicate or reusable logic patterns within this file
+- Whether the file couples multiple unrelated functional modules
+
+#### 2.2 Decide Whether to Split the File
+
+Split into multiple files when the file couples multiple clearly distinct functional modules, making it hard to read and maintain:
+- The decision is based on module coupling, not line count
+- Each resulting file should have focused, single responsibility
+
+When splitting:
+- Name new files clearly to reflect their purpose (e.g., `engine.go` -> `engine.go` + `engine_strategies.go` + `engine_signals.go`)
+- Keep the same package/module, ensure compilation passes
+- Place shared type definitions in the most logical file, or a separate types file
+
+If the file is already focused and coherent, do not split.
+
+After splitting, apply steps 2.3-2.7 to each resulting file.
+
+#### 2.3 Restructure File Layout
+
+Organize code blocks in a logical order based on the file's actual content. Common reference (adapt as needed):
+
+```
+- package/module declaration, imports
+- constants, variables
+- type definitions
+- constructors
+- core business methods
+- helper / utility methods
+```
+
+Core principle: **a reader scanning top-to-bottom should naturally understand the file's structure and business flow**. Keep related code together; high-level logic before implementation details.
+
+Separate functional sections with divider comments:
+
+```
+// ============================================================
+// Order Management
+// ============================================================
+```
+
+#### 2.4 Extract Reusable Logic
+
+Check for duplicate code patterns **within the file being processed** (do not modify files outside the target scope):
+- 2+ occurrences of logic spanning 5+ lines -> extract into a standalone helper
+- 3+ occurrences regardless of length -> extract into a standalone helper
+- Name extracted helpers clearly, place them in the helper/utility section
+
+#### 2.5 Remove Redundancy
+
+- Delete unused functions, types, constants, variables
+- Delete duplicate implementations (keep the better one)
+- Delete meaningless comments (e.g., empty `// TODO`, placeholder `// xxx`)
+- **Do not delete** comments with business meaning or doc comments
+
+#### 2.6 Add Comments
+
+- Section divider comments for each functional area
+- Concise comment before core business methods (one line, explain what it does)
+- Concise comment before type definitions
+- No comments needed for utility methods or self-explanatory code
+- Do not translate existing comments -- leave them as-is
+
+#### 2.7 Verify
+
+Run compilation and test checks on modified files. Detect build/test commands from the project:
+- Go: `go build ./...` then `go test ./...`
+- Rust: `cargo check` then `cargo test`
+- TypeScript: `tsc --noEmit` then `npm test`
+- Python: `python -m py_compile` then `pytest`
+- Other: language-appropriate compile check then test suite
+
+If any check fails, fix the issue and re-check. Max 3 attempts.
+
+### Step 3: Output Report
+
+After each file is processed, briefly report what was done and the build/test result. After all files, output summary:
+
+```
+REORGANIZE COMPLETE
+  Files processed:    {N}
+  Files split:        {list, or "none"}
+  Build:              {PASS / FAIL}
+  Tests:              {PASS / FAIL / no tests found}
+```
+
+## Constraints
+
+- **Preserve functionality and logic** -- this is restructuring, not rewriting. Input/output behavior must remain identical.
+- **Preserve public API** -- exported functions, methods, and type signatures must not change.
+- **Preserve tests** -- if corresponding test files exist, all tests must pass after reorganization.
+- **Conservative splitting** -- only split when a file truly couples multiple distinct modules causing confusion.
+- **Conservative extraction** -- only extract when there is genuine multi-site duplication with meaningful complexity.


### PR DESCRIPTION
## Summary
- Add `skills/reorganize/` — standalone code file restructuring skill (rearrange modules, extract reuse, remove redundancy, add section comments, conservative splitting)
- Integrate as Finalize Step 1 in `code-quality-loop` (before Simplify), with its own build verification
- Multi-language support: Go, Rust, TypeScript, Python build/test detection

## Changes
- `skills/reorganize/SKILL.md` — new skill
- `skills/code-quality-loop/SKILL.md` — add Reorganize step, update step numbering and output format

## Design
Reorganize runs before Simplify because it makes larger structural changes (file splitting, code movement), while Simplify does fine-grained polish. Both are verified by the subsequent Build + Test steps.

## Test plan
- [ ] Run `/review-loop:reorganize diff` standalone on a project with unstaged changes
- [ ] Run `/review-loop:code-quality-loop` and verify Reorganize executes as Finalize Step 1
- [ ] Verify build passes after reorganize + simplify

🤖 Generated with [Claude Code](https://claude.com/claude-code)