### PR TITLE
feat(codex): marketplace install adapter via .codex-plugin/plugin.json

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "review-loop",
+  "version": "2.7.4",
+  "description": "AI-driven code review with independent adversarial review, automated quality polish, and multi-language static analysis. 12 agents, 5 skills, full Plan-Execute-Review-Polish pipeline.",
+  "author": {
+    "name": "NYTC69",
+    "url": "https://github.com/NYTC69"
+  },
+  "repository": "https://github.com/NYTC69/review-loop",
+  "license": "Apache-2.0",
+  "keywords": [
+    "review-loop",
+    "code-review",
+    "agents",
+    "planning",
+    "automation",
+    "dual-agent",
+    "agentic-coding",
+    "codex"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "review-loop",
+    "shortDescription": "Plan-Execute-Review pipeline with independent adversarial review and automated quality polish",
+    "longDescription": "review-loop drives work items from raw description through plan → execute → review → polish → delivery, with an independent reviewer agent (Codex CLI or Claude sub-agent) catching issues before merge. Skills cover full pipeline (review-loop), planning-only (plan), execution-only (execute), code review on changes (review-pr), iterative quality cleanup (code-quality-loop), structural reorganization (reorganize), and usage guidance (guide). Codex Stage 1 ships judgment-tier reviewer + executor as native Codex agents (.codex/agents/*.toml) for cwd-of-repo invocation; marketplace install exposes the skills globally.",
+    "developerName": "NYTC69",
+    "category": "Developer Tools",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "defaultPrompt": [
+      "run review-loop on this branch",
+      "review the pending changes",
+      "plan this task with review-loop"
+    ]
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -18,11 +18,11 @@
     "agentic-coding",
     "codex"
   ],
-  "skills": "./skills/",
+  "skills": "./.agents/skills/",
   "interface": {
     "displayName": "review-loop",
-    "shortDescription": "Plan-Execute-Review pipeline with independent adversarial review and automated quality polish",
-    "longDescription": "review-loop drives work items from raw description through plan → execute → review → polish → delivery, with an independent reviewer agent (Codex CLI or Claude sub-agent) catching issues before merge. Skills cover full pipeline (review-loop), planning-only (plan), execution-only (execute), code review on changes (review-pr), iterative quality cleanup (code-quality-loop), structural reorganization (reorganize), and usage guidance (guide). Codex Stage 1 ships judgment-tier reviewer + executor as native Codex agents (.codex/agents/*.toml) for cwd-of-repo invocation; marketplace install exposes the skills globally.",
+    "shortDescription": "Plan-Execute-Review pipeline with independent adversarial review",
+    "longDescription": "review-loop drives work items from raw description through plan → execute → review → delivery, with an independent reviewer agent catching issues before merge. Codex marketplace install exposes the four Stage 1 native skills (guide, plan, execute, review-loop) under `.agents/skills/`, paired with the reviewer + executor agents at `.codex/agents/*.toml`. The top-level `./skills/` tree (review-pr, code-quality-loop, reorganize, etc.) is Claude Code-specific — it dispatches via the Claude Agent tool and is intentionally not exposed via this Codex manifest.",
     "developerName": "NYTC69",
     "category": "Developer Tools",
     "capabilities": ["Interactive", "Read", "Write"],


### PR DESCRIPTION
## Summary

- Adds `.codex-plugin/plugin.json` so `codex plugin marketplace add https://github.com/NYTC69/review-loop` succeeds. Pre-PR the manifest was missing, so the marketplace install path failed silently — only Claude Code marketplace install + per-cwd `.codex/agents/*.toml` pickup worked.
- Manifest exposes the **Codex Stage 1 native skill tree** (`./.agents/skills/`: guide, plan, execute, review-loop), explicitly NOT the top-level `./skills/` (which is Claude-Code-specific and dispatches via the Claude Agent tool — not executable in Codex).
- No runtime / skill / protocol / version changes. Pure new install entry point.

## Codex review trail (dogfood)

Independent review by `codex exec review --base main` (gpt-5.5):

- **R1** (`dfc0124`): REQUEST_CHANGES (P1) — `skills` pointed at `./skills/` which is Claude-specific, would have shipped a non-functional surface to Codex marketplace users while missing the four real native skills.
- **Fix** (`6a32506`): redirect `skills` to `./.agents/skills/`; tighten `longDescription` to call out the dual-tree split explicitly.
- **R2** (post-fix): "The Codex manifest is valid" — APPROVE on the manifest. Codex flagged a separate P2 on `LEARNINGS.md:40` (a v2.7.4 fast-replay protocol entry) that's unrelated to this change and not staged in any commit on this branch — left for a separate discussion.

## Test plan

- [x] `python3 -m json.tool .codex-plugin/plugin.json` — valid JSON
- [x] Smoke install on research: `codex plugin marketplace add /Users/yuanlei/3Cats/review-loop` → "Added marketplace `review-loop-marketplace`". Cleaned up post-test.
- [ ] After merge, end-to-end on main Mac: `codex plugin marketplace add https://github.com/NYTC69/review-loop`, enable via TUI `/plugins`, invoke `review-loop:guide` and verify it loads from `.agents/skills/guide/SKILL.md`.
- [ ] Confirm reviewer + executor agents (`.codex/agents/*.toml`) remain reachable when working inside the review-loop repo (per-cwd auto-pickup unaffected by this change).

## Notes

- review-loop's existing dual-tree layout (`./skills/` for Claude, `./.agents/skills/` for Codex) is documented in the skills' SKILL.md headers and confirmed by the global wrapper `~/.codex/skills/review-loop/SKILL.md` whose hard-coded "authoritative paths" point exclusively at `.agents/skills/<name>/SKILL.md`. This PR makes the marketplace adapter consistent with that pre-existing design.
- Closes the gap noted in compass closed-backlog ref `0c285a2` ("review-loop 无 Codex adapter, 跳过") — that note was scoped narrowly to the missing manifest, not to runtime support; this PR adds the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)